### PR TITLE
Add convenience functions for configuring global logger

### DIFF
--- a/global_logger.go
+++ b/global_logger.go
@@ -1,5 +1,7 @@
 package logger
 
+import "io"
+
 var globalLogger = New()
 
 func ConfigureGlobalLogger(opts ...LoggerOption) {
@@ -8,11 +10,6 @@ func ConfigureGlobalLogger(opts ...LoggerOption) {
 
 func Global() *Logger {
 	return globalLogger
-}
-
-// SetLogLevel to new Level for global logger
-func SetLogLevel(lvl Level) {
-	globalLogger.SetLevel(lvl)
 }
 
 // WithFields creates log entry using global logger
@@ -68,4 +65,24 @@ func Fatal(args ...interface{}) {
 // Fatalf uses global logger to log payload on "fatal" level
 func Fatalf(format string, args ...interface{}) {
 	globalLogger.Fatalf(format, args...)
+}
+
+// SetNowFunc sets `now` func user by global logger
+func SetNowFunc(nowFunc NowFunc) {
+	ConfigureGlobalLogger(WithNowFunc(nowFunc))
+}
+
+// SetOutput changes global logger's output
+func SetOutput(output io.Writer) {
+	ConfigureGlobalLogger(WithOutput(output))
+}
+
+// SetLevel sets minimum log level for global logger
+func SetLevel(level Level) {
+	ConfigureGlobalLogger(WithLevel(level))
+}
+
+// SetReportCaller allows controling if caller info should be attached to logs by global logger
+func SetReportCaller(enable bool) {
+	ConfigureGlobalLogger(WithReportCaller(enable))
 }

--- a/global_logger_test.go
+++ b/global_logger_test.go
@@ -100,3 +100,27 @@ func TestGlobalLoggerLogLevelsInFormatFuncs(t *testing.T) {
 		})
 	}
 }
+
+func TestGlobalLoggerConvenienveFunctions(t *testing.T) {
+	buf := &bytes.Buffer{}
+	oldOutput := globalLogger.output
+	oldNowFunc := globalLogger.now
+	defer func() {
+		SetOutput(oldOutput)
+		SetNowFunc(oldNowFunc)
+		SetReportCaller(true)
+		SetLevel(globalLogger.level)
+	}()
+	{
+		SetOutput(buf)
+		SetNowFunc(mockNowFunc)
+		SetReportCaller(false)
+	}
+
+	Warn("foobar")
+	assertLogEntryContains(t, buf, "msg", "foobar")
+	Info("I won't be logged because the default log level is higher than info")
+	SetLevel(LevelInfo)
+	Info("but now I will")
+	assertLogEntryContains(t, buf, "msg", "but now I will")
+}

--- a/logger.go
+++ b/logger.go
@@ -55,12 +55,6 @@ func (logger *Logger) entry() Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(fields)
 }
 
-// SetLevel for Logger visibility
-func (logger *Logger) SetLevel(lvl Level) {
-	logger.level = lvl
-	logger.logrusLogger.SetLevel(mapLevelToLogrusLevel(logger.level))
-}
-
 // WithFields forwards a logging call with fields
 func (logger *Logger) WithFields(fields Fields) Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(logrus.Fields(fields))

--- a/logger_test.go
+++ b/logger_test.go
@@ -99,43 +99,6 @@ func TestLogLevels(t *testing.T) {
 	}
 }
 
-func TestLogLevelsSwitch(t *testing.T) {
-	type testCase struct {
-		logFunc          func(args ...interface{})
-		expectedLogLevel string
-	}
-
-	buf := &bytes.Buffer{}
-	testLogger := New(WithOutput(buf), WithLevel(LevelFatal))
-	testLogger.logrusLogger.ExitFunc = func(int) {} // prevent .Fatal() from shutting down test runner
-
-	testCases := map[string]testCase{
-		"logger.Fatal() should log with level fatal": {
-			logFunc:          testLogger.Fatal,
-			expectedLogLevel: "fatal",
-		},
-		"logger.Info() should log with level info": {
-			logFunc:          testLogger.Info,
-			expectedLogLevel: "info",
-		},
-		"logger.Error() should log with level error": {
-			logFunc:          testLogger.Error,
-			expectedLogLevel: "error",
-		},
-		"logger.Warn() should log with level warning": {
-			logFunc:          testLogger.Warn,
-			expectedLogLevel: "warning",
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			testLogger.SetLevel(LevelInfo)
-			tc.logFunc("foobar")
-			assertLogEntryContains(t, buf, "level", tc.expectedLogLevel)
-		})
-	}
-}
-
 func TestLogLevelsInFormatFuncs(t *testing.T) {
 	type testCase struct {
 		logFunc          func(format string, args ...interface{})


### PR DESCRIPTION
Makes the API for configuring global logger a bit more user friendly. Instead of
`logger.ConfigureGlobalLogger(logger.WithLevel(logger.LevelInfo))`
clients can now do
`logger.SetLevel(logger.LevelInfo)`
The same goes for other configuration options.