### PR TITLE
Set default logger's output to stderr

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -37,7 +37,7 @@ func New(opts ...LoggerOption) *Logger {
 	logger := &Logger{
 		logrusLogger: logrusLogger,
 		now:          NowFunc(time.Now),
-		output:       os.Stdout,
+		output:       os.Stderr,
 		level:        LevelWarn,
 		reportCaller: true,
 	}


### PR DESCRIPTION
To be compliant with https://playbook.internal.coop/guidelines/development.html?h=devt#general-tips-and-best-practices:
`Write structured logs to STDERR.`