### PR TITLE
Fix bug when echo framework trying to get output for logs

### DIFF
--- a/adapter/echo/log.go
+++ b/adapter/echo/log.go
@@ -11,8 +11,7 @@ import (
 // WrappedEchoLogger that can be passed to Echo middleware for Datadog integration
 // implements Echo Logger from vendor/github.com/labstack/echo/v4/log.go
 type WrappedEchoLogger struct {
-	log    log.Entry
-	output io.Writer
+	log *log.Logger
 
 	// prefix for logs
 	prefix string
@@ -30,13 +29,11 @@ func NewWrappedEchoLogger() *WrappedEchoLogger {
 
 // Output not supported to access in Coop logger, so it's returns only stub
 func (wel *WrappedEchoLogger) Output() io.Writer {
-	return wel.output
+	return wel.log.OutputHandler()
 }
 
 // SetOutput not supported to change in Coop logger, accepting only stub
-func (wel *WrappedEchoLogger) SetOutput(w io.Writer) {
-	wel.output = w
-}
+func (wel *WrappedEchoLogger) SetOutput(_ io.Writer) {}
 
 func (wel *WrappedEchoLogger) Prefix() string {
 	return wel.prefix

--- a/logger.go
+++ b/logger.go
@@ -60,6 +60,11 @@ func (logger *Logger) WithFields(fields Fields) Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(logrus.Fields(fields))
 }
 
+// OutputHandler returns logger output handler
+func (logger *Logger) OutputHandler() io.Writer {
+	return logger.output
+}
+
 // Infof forwards a logging call in the (format, args) format
 func (logger *Logger) Info(args ...interface{}) {
 	logger.entry().Info(args...)


### PR DESCRIPTION
Echo framework will try get logger output handler in some cases that leads to nulptr exception