### PR TITLE
Add `WithField()` companion to `WithFields()`

### DIFF
--- a/global_logger.go
+++ b/global_logger.go
@@ -12,6 +12,11 @@ func Global() *Logger {
 	return globalLogger
 }
 
+// WithField creates log entry using global logger
+func WithField(key string, value interface{}) Entry {
+	return globalLogger.WithField(key, value)
+}
+
 // WithFields creates log entry using global logger
 func WithFields(fields Fields) Entry {
 	return globalLogger.WithFields(fields)

--- a/logger.go
+++ b/logger.go
@@ -55,6 +55,11 @@ func (logger *Logger) entry() Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(fields)
 }
 
+// WithField forwards a logging call with a field
+func (logger *Logger) WithField(key string, value interface{}) Entry {
+	return logger.logrusLogger.WithTime(logger.now()).WithField(key, value)
+}
+
 // WithFields forwards a logging call with fields
 func (logger *Logger) WithFields(fields Fields) Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(logrus.Fields(fields))

--- a/logger_examples_test.go
+++ b/logger_examples_test.go
@@ -43,8 +43,11 @@ func ExampleWithFields() {
 
 	WithFields(Fields{
 		"timeSpentOnConfiguration": 0,
+		"defaultsLoaded":           true,
 	}).Warn("use default logger with 0 configuration")
-	// Output: {"level":"warning","msg":"use default logger with 0 configuration","time":"2020-10-10T10:10:10Z","timeSpentOnConfiguration":0}
+	WithField("singleField", true).Warn("example with a single field")
+	// Output: {"defaultsLoaded":true,"level":"warning","msg":"use default logger with 0 configuration","time":"2020-10-10T10:10:10Z","timeSpentOnConfiguration":0}
+	// {"level":"warning","msg":"example with a single field","singleField":true,"time":"2020-10-10T10:10:10Z"}
 }
 
 type warner interface {

--- a/logger_test.go
+++ b/logger_test.go
@@ -167,12 +167,16 @@ func TestLoggingCustomFields(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
+		f := func(t *testing.T, useSingle bool) {
 			buf := &bytes.Buffer{}
 			logger := New(WithLevel(LevelDebug), WithOutput(buf))
-			logger.WithFields(Fields{
-				"customField": tc.customFieldValue,
-			}).Warnf("blabla")
+			if useSingle {
+				logger.WithField("customField", tc.customFieldValue).Warnf("blabla")
+			} else {
+				logger.WithFields(Fields{
+					"customField": tc.customFieldValue,
+				}).Warnf("blabla")
+			}
 			log, err := ioutil.ReadAll(buf)
 			if err != nil {
 				t.Fatalf("cannot read buffer: %v", err)
@@ -181,7 +185,9 @@ func TestLoggingCustomFields(t *testing.T) {
 			if !strings.Contains(string(log), expectedLoggedValue) {
 				t.Fatalf("expected to find %v in log (%v)", expectedLoggedValue, string(log))
 			}
-		})
+		}
+		t.Run(name+"_single", func(t *testing.T) { f(t, true) })
+		t.Run(name+"_multiple", func(t *testing.T) { f(t, false) })
 	}
 
 }


### PR DESCRIPTION
From time to time one only has a single field to log parametrically. In logrus this is typically done via `WithField()`. While this library was originally intended somewhat as a standard logging interface and not a 1:1 wrapping of logrus, I still think this is a potentially useful option to have as it avoids constructing an additional fields map with only one item.

It shouldn't be an issue later on if we swap out the logrus library as we can then simply call the `WithFields()` internal implementation with a single field.