### PR TITLE
Go validation via devtools and lint cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 ---
 version: 2
+
+registries:
+  coop-ghcr:
+    type: docker-registry
+    url: ghcr.io
+    username: CoopGithubServiceaccount
+    password: ${{ secrets.DEPENDABOT_GHCR_PULL }}
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -7,5 +15,11 @@ updates:
       interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/docker-compose"
+    registries:
+      - coop-ghcr
     schedule:
       interval: "daily"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,42 @@ on:
     branches-ignore:
       - main
 jobs:
-  build:
+  golang-ci:
+    name: Go Lang CI
+    runs-on: ubuntu-latest
+    env:
+      docker-compose-service: golang-devtools
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache/xdg
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - id: xdg_cache_hash
+        run: echo "xdg_cache_hash=${{hashFiles('./docker-compose.yml', './docker-compose/Dockerfile', './go.sum')}}" >> $GITHUB_OUTPUT
+      - name: Cache xdg
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}
+          key: xdg-${{ github.repository }}-${{ github.job }}-${{ steps.xdg_cache_hash.outputs.xdg_cache_hash }}
+          restore-keys: |
+            xdg-${{ github.repository }}-${{ github.job }}-${{ steps.xdg_cache_hash.outputs.xdg_cache_hash }}
+            xdg-${{ github.repository }}-${{ github.job }}-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure access to internal and private GitHub repos
+        run: git config --global url."https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge"
+      - name: Build devtools
+        run: docker compose build
+      - name: Validate
+        run: docker compose run --rm ${{ env.docker-compose-service }} validate VERBOSE=all
+
+  validate-old-go:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,3 +56,14 @@ jobs:
       - name: Validate
         run: make validate
 
+  build:
+    needs:
+      - golang-ci
+      - validate-old-go
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        name: "Catch errors"
+        if: |
+          needs.golang-ci.result == 'failure'

--- a/adapter/echo/log.go
+++ b/adapter/echo/log.go
@@ -1,4 +1,6 @@
-package labstack_logger
+// Ignore package name lint warning to remain backwards compatible until a breaking change is planned
+
+package labstack_logger //nolint:all
 
 import (
 	"encoding/json"
@@ -35,14 +37,17 @@ func (wel *WrappedEchoLogger) Output() io.Writer {
 // SetOutput not supported to change in Coop logger, accepting only stub
 func (wel *WrappedEchoLogger) SetOutput(_ io.Writer) {}
 
+// Prefix returns the current log prefix
 func (wel *WrappedEchoLogger) Prefix() string {
 	return wel.prefix
 }
 
+// SetPrefix sets a string that will be prefixed to each log line
 func (wel *WrappedEchoLogger) SetPrefix(p string) {
 	wel.prefix = p
 }
 
+// Level returns a mapped Echo log level
 func (wel *WrappedEchoLogger) Level() echo.Lvl {
 	switch wel.level {
 	case log.LevelDebug:
@@ -60,6 +65,7 @@ func (wel *WrappedEchoLogger) Level() echo.Lvl {
 	}
 }
 
+// SetLevel maps the log level from an Echo log level
 func (wel *WrappedEchoLogger) SetLevel(v echo.Lvl) {
 	switch v {
 	case echo.DEBUG:
@@ -80,88 +86,109 @@ func (wel *WrappedEchoLogger) SetLevel(v echo.Lvl) {
 // SetHeader not supported
 func (wel *WrappedEchoLogger) SetHeader(_ string) {}
 
+// Print logs at the info level
 func (wel *WrappedEchoLogger) Print(i ...interface{}) {
 	wel.log.Info(i...)
 }
 
+// Printf logs formatted output at the info level
 func (wel *WrappedEchoLogger) Printf(format string, args ...interface{}) {
 	wel.log.Infof(format, args...)
 }
 
+// Printj marshals a map to JSON and and logs it at the info level
 func (wel *WrappedEchoLogger) Printj(j echo.JSON) {
 	wel.log.Info(wel.jsonToString(j))
 }
 
+// Debug logs at the debug level
 func (wel *WrappedEchoLogger) Debug(i ...interface{}) {
 	wel.log.Debug(i...)
 }
 
+// Debugf logs formatted output at the debug level
 func (wel *WrappedEchoLogger) Debugf(format string, args ...interface{}) {
 	wel.log.Debugf(format, args...)
 }
 
+// Debugj marshals a map to JSON and and logs it at the debug level
 func (wel *WrappedEchoLogger) Debugj(j echo.JSON) {
 	wel.log.Debug(wel.jsonToString(j))
 }
 
+// Info logs at the info level
 func (wel *WrappedEchoLogger) Info(i ...interface{}) {
 	wel.log.Info(i...)
 }
 
+// Infof logs formatted output at the info level
 func (wel *WrappedEchoLogger) Infof(format string, args ...interface{}) {
 	wel.log.Infof(format, args...)
 }
 
+// Infoj marshals a map to JSON and and logs it at the info level
 func (wel *WrappedEchoLogger) Infoj(j echo.JSON) {
 	wel.log.Info(wel.jsonToString(j))
 }
 
+// Warn logs at the warn level
 func (wel *WrappedEchoLogger) Warn(i ...interface{}) {
 	wel.log.Warn(i...)
 }
 
+// Warnf logs formatted output at the warn level
 func (wel *WrappedEchoLogger) Warnf(format string, args ...interface{}) {
 	wel.log.Warnf(format, args...)
 }
 
+// Warnj marshals a map to JSON and and logs it at the warn level
 func (wel *WrappedEchoLogger) Warnj(j echo.JSON) {
 	wel.log.Warn(wel.jsonToString(j))
 }
 
+// Error logs at the error level
 func (wel *WrappedEchoLogger) Error(i ...interface{}) {
 	wel.log.Error(i...)
 }
 
+// Errorf logs formatted output at the error level
 func (wel *WrappedEchoLogger) Errorf(format string, args ...interface{}) {
 	wel.log.Errorf(format, args...)
 }
 
+// Errorj marshals a map to JSON and and logs it at the error level
 func (wel *WrappedEchoLogger) Errorj(j echo.JSON) {
 	wel.log.Error(wel.jsonToString(j))
 }
 
+// Fatal logs fatally
 func (wel *WrappedEchoLogger) Fatal(i ...interface{}) {
 	wel.log.Fatal(i...)
 }
 
-func (wel *WrappedEchoLogger) Fatalj(j echo.JSON) {
-	wel.log.Fatal(wel.jsonToString(j))
-}
-
+// Fatalf logs formatted output fatally
 func (wel *WrappedEchoLogger) Fatalf(format string, args ...interface{}) {
 	wel.log.Fatalf(format, args...)
 }
 
+// Fatalj marshals a map to JSON and and logs it fatally
+func (wel *WrappedEchoLogger) Fatalj(j echo.JSON) {
+	wel.log.Fatal(wel.jsonToString(j))
+}
+
+// Panic wraps a call to Fatal
 func (wel *WrappedEchoLogger) Panic(i ...interface{}) {
 	wel.log.Fatal(i...)
 }
 
-func (wel *WrappedEchoLogger) Panicj(j echo.JSON) {
-	wel.log.Fatal(wel.jsonToString(j))
-}
-
+// Panicf wraps a call to Fatalf
 func (wel *WrappedEchoLogger) Panicf(format string, args ...interface{}) {
 	wel.log.Fatalf(format, args...)
+}
+
+// Panicj wraps a call to Fatalj
+func (wel *WrappedEchoLogger) Panicj(j echo.JSON) {
+	wel.log.Fatal(wel.jsonToString(j))
 }
 
 func (wel *WrappedEchoLogger) jsonToString(j echo.JSON) string {

--- a/adapter/echo/log_test.go
+++ b/adapter/echo/log_test.go
@@ -1,4 +1,6 @@
-package labstack_logger
+// Ignore package name lint warning to remain backwards compatible until a breaking change is planned
+
+package labstack_logger //nolint:all
 
 import (
 	"bytes"
@@ -7,7 +9,7 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
-func TestWrappedEchoLogger(t *testing.T) {
+func TestWrappedEchoLogger(_ *testing.T) {
 	l := NewWrappedEchoLogger()
 	jTest := log.JSON{"name": "value"}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  golang-devtools:
+    build:
+      context: docker-compose
+      target: golang-devtools
+      dockerfile: Dockerfile
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - .:/srv/workspace:z
+      - ${DOCKER_CONFIG:-~/.docker}:/root/.docker
+      - ${GIT_CONFIG:-~/.gitconfig}:${GIT_CONFIG_GUEST:-/root/.gitconfig}
+      - ${SSH_CONFIG:-~/.ssh}:/root/.ssh
+      - ${XDG_CACHE_HOME:-xdg-cache-home}:/root/.cache
+      # ${x:-y} explained here https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#:~:text=3.5.3%20Shell%20Parameter%20Expansion
+    environment:
+      GOMODCACHE: /root/.cache/go-mod
+volumes:
+  xdg-cache-home: { }

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:gitc-1f40b7aec2da97d51ed26c6f1d027bdee0458a0d@sha256:5abec21bdbd1fec9946a50e825692773a64e7db2ddd10d3446e1fc70cfcbca3b AS golang-devtools

--- a/global_logger.go
+++ b/global_logger.go
@@ -4,10 +4,12 @@ import "io"
 
 var globalLogger = New()
 
+// ConfigureGlobalLogger applies supplied logger options to the global logger
 func ConfigureGlobalLogger(opts ...LoggerOption) {
 	globalLogger.applyOptions(opts...)
 }
 
+// Global logger that can be accessed without prior instantiation
 func Global() *Logger {
 	return globalLogger
 }
@@ -17,7 +19,7 @@ func WithFields(fields Fields) Entry {
 	return globalLogger.WithFields(fields)
 }
 
-// Infof uses global logger to log payload on "info" level
+// Info uses global logger to log payload on "info" level
 func Info(args ...interface{}) {
 	globalLogger.Info(args...)
 }
@@ -82,7 +84,7 @@ func SetLevel(level Level) {
 	ConfigureGlobalLogger(WithLevel(level))
 }
 
-// SetReportCaller allows controling if caller info should be attached to logs by global logger
+// SetReportCaller allows controlling if caller info should be attached to logs by global logger
 func SetReportCaller(enable bool) {
 	ConfigureGlobalLogger(WithReportCaller(enable))
 }

--- a/level.go
+++ b/level.go
@@ -2,10 +2,11 @@ package logger
 
 import "github.com/sirupsen/logrus"
 
+// Level is an integer representation of the logging level
 type Level uint8
 
 const (
-	// LevelFatal is to be used to log predictable errors that make the service unsuable, eg misconfiguration. After logging, the app will be shut down.
+	// LevelFatal is to be used to log predictable errors that make the service unusable, eg misconfiguration. After logging, the app will be shut down.
 	LevelFatal = iota
 	// LevelError  isto be used for recoverable errors that limit the service's functionality, eg timeouts.
 	LevelError

--- a/logger.go
+++ b/logger.go
@@ -12,6 +12,7 @@ import (
 // Fields type, used to pass to `WithFields`.
 type Fields map[string]interface{}
 
+// NowFunc is a typedef for a function which returns the current time
 type NowFunc func() time.Time
 
 // Logger is our logger with the needed structured logger we use
@@ -31,6 +32,7 @@ func (logger *Logger) applyOptions(opts ...LoggerOption) {
 	logger.logrusLogger.SetLevel(mapLevelToLogrusLevel(logger.level))
 }
 
+// New creates and returns a new logger with supplied options
 func New(opts ...LoggerOption) *Logger {
 	logrusLogger := logrus.New()
 	logrusLogger.SetFormatter(&logrus.JSONFormatter{})
@@ -65,7 +67,7 @@ func (logger *Logger) OutputHandler() io.Writer {
 	return logger.output
 }
 
-// Infof forwards a logging call in the (format, args) format
+// Info forwards a logging call in the (format, args) format
 func (logger *Logger) Info(args ...interface{}) {
 	logger.entry().Info(args...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -183,7 +183,6 @@ func TestLoggingCustomFields(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func contains(levels []Level, level Level) bool {

--- a/opts.go
+++ b/opts.go
@@ -2,12 +2,15 @@ package logger
 
 import "io"
 
-type LoggerOption interface {
+// LoggerOption defines an applicator interface
+type LoggerOption interface { //nolint:all
 	Apply(l *Logger)
 }
 
-type LoggerOptionFunc func(l *Logger)
+// LoggerOptionFunc defines a function which modifies a logger
+type LoggerOptionFunc func(l *Logger) //nolint:all
 
+// Apply redirects a function call to the function receiver
 func (lof LoggerOptionFunc) Apply(l *Logger) {
 	lof(l)
 }


### PR DESCRIPTION
Add devtools and make use of them in CI validation.

I have left the existing CI validation steps in for now, I will address them in follow-up PRs.