### PR TITLE
Add WithError(), and name to log level conversion

### DIFF
--- a/global_logger.go
+++ b/global_logger.go
@@ -14,6 +14,11 @@ func Global() *Logger {
 	return globalLogger
 }
 
+// WithError is a convenience wrapper for WithField("err", err)
+func WithError(err error) Entry {
+	return globalLogger.WithError(err)
+}
+
 // WithField creates log entry using global logger
 func WithField(key string, value interface{}) Entry {
 	return globalLogger.WithField(key, value)

--- a/level.go
+++ b/level.go
@@ -1,6 +1,10 @@
 package logger
 
-import "github.com/sirupsen/logrus"
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
 
 // Level is an integer representation of the logging level
 type Level uint8
@@ -17,6 +21,20 @@ const (
 	// LevelDebug should only be used in dev/test environments.
 	LevelDebug
 )
+
+var nameMapping = map[string]Level{
+	"fatal": LevelFatal,
+	"error": LevelError,
+	"warn":  LevelWarn,
+	"info":  LevelInfo,
+	"debug": LevelDebug,
+}
+
+// LevelNameToLevel converts a named log level to the Level type
+func LevelNameToLevel(name string) (l Level, ok bool) {
+	l, ok = nameMapping[strings.ToLower(name)]
+	return
+}
 
 func mapLevelToLogrusLevel(l Level) logrus.Level {
 	switch l {

--- a/logger.go
+++ b/logger.go
@@ -57,6 +57,13 @@ func (logger *Logger) entry() Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(fields)
 }
 
+const errorKey = "error"
+
+// WithError is a convenience wrapper for WithField("error", err)
+func (logger *Logger) WithError(err error) Entry {
+	return logger.WithField(errorKey, err)
+}
+
 // WithField forwards a logging call with a field
 func (logger *Logger) WithField(key string, value interface{}) Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithField(key, value)

--- a/logger_examples_test.go
+++ b/logger_examples_test.go
@@ -4,6 +4,7 @@
 package logger
 
 import (
+	"errors"
 	"os"
 	"time"
 )
@@ -23,6 +24,12 @@ func ExampleInfo() {
 
 func ExampleWithLevel() {
 	logger := New(WithNowFunc(mockNowFunc), WithLevel(LevelInfo), WithReportCaller(false))
+	logger.Info("now log level is set to info or lower, I will be logged")
+	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10Z"}
+}
+
+func ExampleWithLevelName() {
+	logger := New(WithNowFunc(mockNowFunc), WithLevelName("info"), WithReportCaller(false))
 	logger.Info("now log level is set to info or lower, I will be logged")
 	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10Z"}
 }
@@ -48,6 +55,14 @@ func ExampleWithFields() {
 	WithField("singleField", true).Warn("example with a single field")
 	// Output: {"defaultsLoaded":true,"level":"warning","msg":"use default logger with 0 configuration","time":"2020-10-10T10:10:10Z","timeSpentOnConfiguration":0}
 	// {"level":"warning","msg":"example with a single field","singleField":true,"time":"2020-10-10T10:10:10Z"}
+}
+
+func ExampleWithError() {
+	logger := New(WithNowFunc(mockNowFunc), WithReportCaller(false))
+
+	err := errors.New("Test error")
+	logger.WithError(err).Error("Operation failed")
+	// Output: {"error":"Test error","level":"error","msg":"Operation failed","time":"2020-10-10T10:10:10Z"}
 }
 
 type warner interface {

--- a/logger_test.go
+++ b/logger_test.go
@@ -270,6 +270,22 @@ func TestSettingLogLevel(t *testing.T) {
 	}
 }
 
+func TestWithLevelName(t *testing.T) {
+	for name, lvl := range nameMapping {
+		logger := New(WithLevelName(name))
+		if logger.level != lvl {
+			t.Fatalf("expected level %v, got %v", lvl, logger.logrusLogger.Level)
+		}
+	}
+}
+
+func TestBadLevelName(t *testing.T) {
+	_, ok := LevelNameToLevel("invalid")
+	if ok {
+		t.Fatalf("Invalid level should not be ok")
+	}
+}
+
 func TestReporingCaller(t *testing.T) {
 	buf := &bytes.Buffer{}
 	tee := io.TeeReader(buf, buf)

--- a/opts.go
+++ b/opts.go
@@ -37,6 +37,18 @@ func WithLevel(level Level) LoggerOption {
 	})
 }
 
+// WithLevelName sets minimum level for filtering logs by name
+func WithLevelName(level string) LoggerOption {
+	return LoggerOptionFunc(func(l *Logger) {
+		lvl, ok := LevelNameToLevel(level)
+		if !ok {
+			lvl = LevelWarn
+			l.Warn("Invalid log level, defaulting to Warn")
+		}
+		l.level = lvl
+	})
+}
+
 // WithReportCaller allows enabling/disabling including calling method in the log entry
 func WithReportCaller(enable bool) LoggerOption {
 	return LoggerOptionFunc(func(l *Logger) {


### PR DESCRIPTION
- Add a `WithError()` shortcut for `WithField("error", err)` so it's easy to log errors parametrically
- Add some name-to-log-level conversion to make it easer to parse these directly from service configs or env vars instead of needing to know the log level number.

I've kept the existing `WithLevel()` function signature the same for backwards compatibility.