### PR TITLE
Update go to the oldest supported version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16', '1.17', '1.18', '1.19', '1.20', '1.21' ]
+        go: [ '1.20', '1.21' ]
     name: Go ${{ matrix.go }} - validate
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-logger
 
-go 1.17
+go 1.20
 
 require (
 	github.com/labstack/gommon v0.4.0

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"testing"
@@ -177,7 +176,7 @@ func TestLoggingCustomFields(t *testing.T) {
 					"customField": tc.customFieldValue,
 				}).Warnf("blabla")
 			}
-			log, err := ioutil.ReadAll(buf)
+			log, err := io.ReadAll(buf)
 			if err != nil {
 				t.Fatalf("cannot read buffer: %v", err)
 			}
@@ -201,7 +200,7 @@ func contains(levels []Level, level Level) bool {
 }
 
 func wasLogged(t *testing.T, logReader io.Reader) bool {
-	b, err := ioutil.ReadAll(logReader)
+	b, err := io.ReadAll(logReader)
 	if err != nil && err != io.EOF {
 		t.Fatalf("cannot read log entry: %v", err)
 	}


### PR DESCRIPTION
> Each major Go release is supported until there are two newer major
> releases. For example, Go 1.5 was supported until the Go 1.7 release,
> and Go 1.6 was supported until the Go 1.8 release. We fix critical
> problems, including critical security problems, in supported releases as
> needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and
> so on).

Ref: https://go.dev/doc/devel/release

Closes: #57
