### PR TITLE
feat: Add support for log-hooks

### DIFF
--- a/global_logger.go
+++ b/global_logger.go
@@ -1,6 +1,9 @@
 package logger
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 var globalLogger = New()
 
@@ -27,6 +30,11 @@ func WithField(key string, value interface{}) Entry {
 // WithFields creates log entry using global logger
 func WithFields(fields Fields) Entry {
 	return globalLogger.WithFields(fields)
+}
+
+// WithContext creates log entry using global logger
+func WithContext(ctx context.Context) Entry {
+	return globalLogger.WithContext(ctx)
 }
 
 // Info uses global logger to log payload on "info" level

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,71 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hook defines the interface a custom Hook needs to implement
+type Hook interface {
+	Fire(*HookEntry) (changed bool, err error)
+}
+
+// HookFunc can be used to convert a simple function to implement the Hook interface.
+type HookFunc func(*HookEntry) (changed bool, err error)
+
+// Fire redirects a function call to the function receiver
+func (hf HookFunc) Fire(he *HookEntry) (changed bool, err error) {
+	return hf(he)
+}
+
+// HookEntry contains the fields provided for mutation in a hook.
+type HookEntry struct {
+	// Contains all the fields set by the user.
+	Data Fields
+
+	// Level the log entry was logged at: Trace, Debug, Info, Warn, Error, Fatal or Panic
+	// This field will be set on entry firing and the value will be equal to the one in Logger struct field.
+	Level Level
+
+	// Message passed to Trace, Debug, Info, Warn, Error, Fatal or Panic
+	Message string
+
+	// Contains the context set by the user. Useful for hook processing etc.
+	Context context.Context
+}
+
+type customHook struct {
+	hook Hook
+}
+
+// Levels implements the logrus.Hook interface.
+func (h *customHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire implements the logrus.Hook interface.
+func (h *customHook) Fire(entry *logrus.Entry) error {
+	// Provide all entry-data so the hook can mutate them.
+	hookEntry := &HookEntry{
+		Data:    Fields(entry.Data),
+		Level:   mapLogrusLevelToLevel(entry.Level),
+		Message: entry.Message,
+		Context: entry.Context,
+	}
+	changed, err := h.hook.Fire(hookEntry)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+
+	// Mutate the actual logrus entry with the mutations done in the hook.
+	entry.Data = logrus.Fields(hookEntry.Data)
+	entry.Level = mapLevelToLogrusLevel(hookEntry.Level)
+	entry.Message = hookEntry.Message
+	entry.Context = hookEntry.Context
+
+	return nil
+}

--- a/level.go
+++ b/level.go
@@ -52,3 +52,20 @@ func mapLevelToLogrusLevel(l Level) logrus.Level {
 	// should never get here
 	return logrus.DebugLevel
 }
+
+func mapLogrusLevelToLevel(l logrus.Level) Level {
+	switch l {
+	case logrus.FatalLevel:
+		return LevelFatal
+	case logrus.ErrorLevel:
+		return LevelError
+	case logrus.WarnLevel:
+		return LevelWarn
+	case logrus.InfoLevel:
+		return LevelInfo
+	case logrus.DebugLevel:
+		return LevelDebug
+	}
+	// should never get here
+	return LevelDebug
+}

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -72,6 +73,11 @@ func (logger *Logger) WithField(key string, value interface{}) Entry {
 // WithFields forwards a logging call with fields
 func (logger *Logger) WithFields(fields Fields) Entry {
 	return logger.logrusLogger.WithTime(logger.now()).WithFields(logrus.Fields(fields))
+}
+
+// WithContext forwards a logging call with fields
+func (logger *Logger) WithContext(ctx context.Context) Entry {
+	return logger.logrusLogger.WithTime(logger.now()).WithContext(ctx)
 }
 
 // OutputHandler returns logger output handler

--- a/opts.go
+++ b/opts.go
@@ -55,3 +55,15 @@ func WithReportCaller(enable bool) LoggerOption {
 		l.reportCaller = enable
 	})
 }
+
+// WithHookFunc allows for connecting a hook to the logger, which will be triggered on all log-entries.
+func WithHookFunc(hook HookFunc) LoggerOption {
+	return WithHook(hook)
+}
+
+// WithHook allows for connecting a hook to the logger, which will be triggered on all log-entries.
+func WithHook(hook Hook) LoggerOption {
+	return LoggerOptionFunc(func(l *Logger) {
+		l.logrusLogger.Hooks.Add(&customHook{hook: hook})
+	})
+}


### PR DESCRIPTION
Implemented using a custom struct HookEntry, to avoid exposing implementation-detail of logrus in our hooks. Might make the transition to another log-library easier.

Closes #29