### PR TITLE
chore(build): Bump golang-devtools to latest version

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:gitc-1f40b7aec2da97d51ed26c6f1d027bdee0458a0d@sha256:5abec21bdbd1fec9946a50e825692773a64e7db2ddd10d3446e1fc70cfcbca3b AS golang-devtools
+FROM ghcr.io/coopnorge/engineering-docker-images/e0/devtools-golang-v1beta1:latest@sha256:1051ac477d9aad7873b27f52e166f40771ca77c89afa2d7e74b0fa66d0cafa8a AS golang-devtools


### PR DESCRIPTION
`golang-devtools` where locked to an old version in a way that
Dependabot cannot update.