### PR TITLE
fix: Fix ReportCaller file/line-number

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 )
@@ -44,62 +45,80 @@ func (e *Entry) WithContext(ctx context.Context) *Entry {
 	return &Entry{logger: e.logger, fields: e.fields, context: ctx}
 }
 
+func addCallerFields(logrusFields logrus.Fields, reportCaller bool) {
+	if reportCaller {
+		frame := getCaller()
+		logrusFields["file"] = fmt.Sprintf("%s:%v", frame.File, frame.Line)
+		logrusFields["function"] = frame.Function
+	}
+}
+
 // Info forwards a logging call in the (format, args) format
 func (e *Entry) Info(args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Info(args...)
 }
 
 // Infof forwards a logging call in the (format, args) format
 func (e *Entry) Infof(format string, args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Infof(format, args...)
 }
 
 // Error forwards an error logging call
 func (e *Entry) Error(args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Error(args...)
 }
 
 // Errorf forwards an error logging call
 func (e *Entry) Errorf(format string, args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Errorf(format, args...)
 }
 
 // Debug forwards a debugging logging call
 func (e *Entry) Debug(args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Debug(args...)
 }
 
 // Debugf forwards a debugging logging call
 func (e *Entry) Debugf(format string, args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Debugf(format, args...)
 }
 
 // Warn forwards a warning logging call
 func (e *Entry) Warn(args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Warn(args...)
 }
 
 // Warnf forwards a warning logging call
 func (e *Entry) Warnf(format string, args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Warnf(format, args...)
 }
 
 // Fatal forwards a fatal logging call
 func (e *Entry) Fatal(args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Fatal(args...)
 }
 
 // Fatalf forwards a fatal logging call
 func (e *Entry) Fatalf(format string, args ...interface{}) {
 	logrusFields := logrus.Fields(e.fields)
+	addCallerFields(logrusFields, e.logger.reportCaller)
 	e.logger.logrusLogger.WithContext(e.context).WithTime(e.logger.now()).WithFields(logrusFields).Fatalf(format, args...)
 }

--- a/logger.go
+++ b/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"time"
@@ -49,14 +48,7 @@ func New(opts ...LoggerOption) *Logger {
 }
 
 func (logger *Logger) entry() *Entry {
-	fields := Fields{}
-	if logger.reportCaller {
-		frame := getCaller()
-		fields["file"] = fmt.Sprintf("%s:%v", frame.File, frame.Line)
-		fields["function"] = frame.Function
-	}
-
-	return &Entry{logger: logger, fields: fields}
+	return &Entry{logger: logger, fields: Fields{}}
 }
 
 const errorKey = "error"


### PR DESCRIPTION
ReportCaller was reporting the file/line-number that the logger-entry was created on, not the file/line-number that actually logged the message (e.g. the `.Info`-call)

Fixes https://github.com/coopnorge/go-logger/issues/85