### PR TITLE
feat: Add controls for Gorm SQL trace logging

### DIFF
--- a/adapter/gorm/options.go
+++ b/adapter/gorm/options.go
@@ -30,3 +30,10 @@ func WithLogger(logger *coopLogger.Logger) LoggerOption {
 		l.instance = logger
 	})
 }
+
+// WithSQLTrace configures Gorm to output SQL trace logs
+func WithSQLTrace() LoggerOption {
+	return LoggerOptionFunc(func(l *Logger) {
+		l.traceEnabled = true
+	})
+}


### PR DESCRIPTION
Disable Gorm SQL trace logging by default pass `WithSQLTrace()` to
`NewLogger()` to enable SQL trace logs
