### PR TITLE
fix: Go directive should use the full version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-logger
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/glebarez/sqlite v1.11.0


### PR DESCRIPTION
Ref: https://inventory.internal.coop/docs/default/component/guidelines/languages/go/#the-gomod-file
