### PR TITLE
chore(deps):  Bump Go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-logger
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/glebarez/sqlite v1.11.0


### PR DESCRIPTION
Ref:
- https://github.com/coopnorge/engineering-issues/issues/439
