### PR TITLE
feat: Add sub-second precision to logs

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -35,7 +35,9 @@ func (logger *Logger) applyOptions(opts ...LoggerOption) {
 // New creates and returns a new logger with supplied options
 func New(opts ...LoggerOption) *Logger {
 	logrusLogger := logrus.New()
-	logrusLogger.SetFormatter(&logrus.JSONFormatter{})
+	logrusLogger.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.999Z07:00", // Adds milliseconds to the time-output
+	})
 	logger := &Logger{
 		logrusLogger: logrusLogger,
 		now:          NowFunc(time.Now),

--- a/logger_examples_test.go
+++ b/logger_examples_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func mockNowFunc() time.Time {
-	return time.Date(2020, 10, 10, 10, 10, 10, 10, time.UTC)
+	return time.Date(2020, 10, 10, 10, 10, 10, 1000000, time.UTC)
 }
 
 func ExampleInfo() {
@@ -18,20 +18,20 @@ func ExampleInfo() {
 	logger.Warn("foobar")
 	logger.Info("i won't be logged because the default log level is higher than info")
 	logger.Error("foobar")
-	// Output: {"level":"warning","msg":"foobar","time":"2020-10-10T10:10:10Z"}
-	// {"level":"error","msg":"foobar","time":"2020-10-10T10:10:10Z"}
+	// Output: {"level":"warning","msg":"foobar","time":"2020-10-10T10:10:10.001Z"}
+	// {"level":"error","msg":"foobar","time":"2020-10-10T10:10:10.001Z"}
 }
 
 func ExampleWithLevel() {
 	logger := New(WithNowFunc(mockNowFunc), WithLevel(LevelInfo), WithReportCaller(false))
 	logger.Info("now log level is set to info or lower, I will be logged")
-	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10Z"}
+	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10.001Z"}
 }
 
 func ExampleWithLevelName() {
 	logger := New(WithNowFunc(mockNowFunc), WithLevelName("info"), WithReportCaller(false))
 	logger.Info("now log level is set to info or lower, I will be logged")
-	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10Z"}
+	// Output: {"level":"info","msg":"now log level is set to info or lower, I will be logged","time":"2020-10-10T10:10:10.001Z"}
 }
 
 func ExampleWithFields() {
@@ -53,8 +53,8 @@ func ExampleWithFields() {
 		"defaultsLoaded":           true,
 	}).Warn("use default logger with 0 configuration")
 	WithField("singleField", true).Warn("example with a single field")
-	// Output: {"defaultsLoaded":true,"level":"warning","msg":"use default logger with 0 configuration","time":"2020-10-10T10:10:10Z","timeSpentOnConfiguration":0}
-	// {"level":"warning","msg":"example with a single field","singleField":true,"time":"2020-10-10T10:10:10Z"}
+	// Output: {"defaultsLoaded":true,"level":"warning","msg":"use default logger with 0 configuration","time":"2020-10-10T10:10:10.001Z","timeSpentOnConfiguration":0}
+	// {"level":"warning","msg":"example with a single field","singleField":true,"time":"2020-10-10T10:10:10.001Z"}
 }
 
 func ExampleWithError() {
@@ -62,7 +62,7 @@ func ExampleWithError() {
 
 	err := errors.New("Test error")
 	logger.WithError(err).Error("Operation failed")
-	// Output: {"error":"Test error","level":"error","msg":"Operation failed","time":"2020-10-10T10:10:10Z"}
+	// Output: {"error":"Test error","level":"error","msg":"Operation failed","time":"2020-10-10T10:10:10.001Z"}
 }
 
 type warner interface {
@@ -82,5 +82,5 @@ func ExampleGlobal() {
 	ConfigureGlobalLogger(WithOutput(os.Stdout), WithNowFunc(mockNowFunc), WithReportCaller(false))
 
 	funcThatAcceptsInterface(Global())
-	// Output: {"level":"warning","msg":"foobar","time":"2020-10-10T10:10:10Z"}
+	// Output: {"level":"warning","msg":"foobar","time":"2020-10-10T10:10:10.001Z"}
 }


### PR DESCRIPTION
Datadog will now start to use the `time` field from our logs as the timestamp for the Log-explorer. By outputting milliseconds in the output, we will get a more precise mapping in Datadog.

The default `TimestampFormat` in `logrus` is `time.RFC3339` ( `"2006-01-02T15:04:05Z07:00"`)