### PR TITLE
chore: Bump Go in CI to supported versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ['1.22', '1.23']
+        go: ['1.23', '1.24']
     name: Go ${{ matrix.go }} - validate
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Go 1.22 is no longer supported and go-logger requires Go 1.23. There is
no need to check if this compiles with Go 1.22.
