### PR TITLE
chore(package): Upgrade to go 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/go-logger
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/glebarez/sqlite v1.11.0


### PR DESCRIPTION
Updates go to version 1.25.0 and runs `go mod tidy`.

Before:
  `go 1.24.0`

After:
  `go 1.25.0`

More details can be found here:
- This PR seeks to address https://github.com/coopnorge/engineering-issues/issues/451
