### PR TITLE
docs(catalog): add description and tags

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,6 +2,17 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: go-logger
+  description: >-
+    Standard structured logging library for all Go services at Coop. Outputs
+    JSON with log level, file, function and timestamp by default. Integrates
+    with go-datadog-lib for trace-correlated log entries.
+  tags:
+    - go
+    - logging
+    - observability
+    - gorm
+    - kratos
+    - goose
   annotations:
     github.com/project-slug: coopnorge/go-logger
     backstage.io/techdocs-ref: dir:.


### PR DESCRIPTION
The catalog entry lacked a description and meaningful tags, making
it invisible to AI-assisted tooling and hard to discover in
Backstage.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
