### PR TITLE
fix: Gracefully handle nil-hooks

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -506,6 +506,22 @@ func TestHookWithoutContext(t *testing.T) {
 	assertLogEntryDoesNotHaveKey(t, tee, "my-custom-log-key")
 }
 
+func TestNilHook(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(WithOutput(buf), WithHook(nil))
+	assert.NotPanics(t, func() {
+		logger.Error("foobar")
+	})
+}
+
+func TestNilHookFunc(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(WithOutput(buf), WithHookFunc(nil))
+	assert.NotPanics(t, func() {
+		logger.Error("foobar")
+	})
+}
+
 func TestReuseEntry(t *testing.T) {
 	builder := &strings.Builder{}
 	logger := New(WithOutput(builder), WithLevel(LevelInfo))

--- a/opts.go
+++ b/opts.go
@@ -61,12 +61,18 @@ func WithReportCaller(enable bool) LoggerOption {
 
 // WithHookFunc allows for connecting a hook to the logger, which will be triggered on all log-entries.
 func WithHookFunc(hook HookFunc) LoggerOption {
+	if hook == nil {
+		return WithHook(nil)
+	}
 	return WithHook(hook)
 }
 
 // WithHook allows for connecting a hook to the logger, which will be triggered on all log-entries.
 func WithHook(hook Hook) LoggerOption {
 	return LoggerOptionFunc(func(l *Logger) {
+		if hook == nil {
+			return
+		}
 		l.logrusLogger.Hooks.Add(&logrusHook{hook: hook})
 	})
 }


### PR DESCRIPTION
This will allow a function to conditionally return a hook, and do nothing if it's `nil`.

Closes https://github.com/coopnorge/go-telemetry-lib/issues/57